### PR TITLE
Safecracker select list support

### DIFF
--- a/bw_required_category/ext.bw_required_category.php
+++ b/bw_required_category/ext.bw_required_category.php
@@ -116,7 +116,7 @@ class Bw_required_category_ext
     // If channel doesn't have to be checked for categories, skip the check
     if ( ! in_array($channel_id, $this->enabled_channels)) return TRUE;
     
-    if ( ! is_array($categories) OR count($categories) === 0)
+    if ( ! is_array($categories) OR count($categories) === 0 OR (count($categories) === 1 && empty($categories[0])) )
     {
       return FALSE;
     }


### PR DESCRIPTION
**Support for select list with required category.**
Option value="0" or value="" would normally pass validation.
this pull request checks if count==1 AND count[0] == empty 
Selecting the "Choose..." item won't pass validation anymore.

```
        <select name="category[]" id="categories">
            <option value="">Choose...</option>
            {categories}
            <option value="{category_id}"{selected}>{category_name}</option>
            {/categories}
        </select>
```
